### PR TITLE
Guardfile: Added quick-n-dirty hack to auto-build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'guard-shell'
+gem 'rubocop'
+gem 'sys-proctable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,63 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.2.0)
+    coderay (1.1.0)
+    ffi (1.9.10)
+    formatador (0.2.5)
+    guard (2.13.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, <= 4.0)
+      lumberjack (~> 1.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-shell (0.7.1)
+      guard (>= 2.0.0)
+      guard-compat (~> 1.0)
+    listen (3.0.6)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9.7)
+    lumberjack (1.0.10)
+    method_source (0.8.2)
+    nenv (0.3.0)
+    notiffany (0.0.8)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    parser (2.3.0.5)
+      ast (~> 2.2)
+    powerpack (0.1.1)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rainbow (2.1.0)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.7)
+      ffi (>= 0.5.0)
+    rubocop (0.37.2)
+      parser (>= 2.3.0.4, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 0.3)
+    ruby-progressbar (1.7.5)
+    shellany (0.0.1)
+    slop (3.6.0)
+    sys-proctable (1.0.0)
+    thor (0.19.1)
+    unicode-display_width (0.3.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  guard-shell
+  rubocop
+  sys-proctable
+
+BUNDLED WITH
+   1.11.2

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,41 @@
+# rubocop:disable LineLength
+# rubocop:disable AndOr
+
+require 'sys/proctable'
+
+app_root = ENV['APP_ROOT'] or abort 'Error: You must point the APP_ROOT environment variable to your application root.'
+
+class GFilter
+  def self.run(files, &_block)
+    @mtimes ||= {}
+
+    files.each do |f|
+      mtime = File.mtime(f)
+      next if @mtimes[f] == mtime
+      @mtimes[f] = mtime
+
+      yield f
+    end
+  end
+end
+
+def kill_server_process
+  Sys::ProcTable.ps.each do |ps|
+    next unless ps.comm.casecmp('copper') == 0
+    Process.kill('KILL', ps.pid)
+  end
+end
+
+guard :shell, all_on_start: true do
+  watch(%r{^src/}) do |m|
+    # Tends to get called multiple times on startup, hence this is needed.
+    GFilter.run(m) do
+      kill_server_process
+      system "cargo run #{app_root} &"
+    end
+  end
+end
+
+at_exit do
+  kill_server_process
+end


### PR DESCRIPTION
This was quite quickly done, answering the need of "support a fast compile-edit-run cycle". The cycle isn't _extremely_ fast; I think some of you would find it too slow. Still, it's good as a starting point. Of course, if we could make this use dynamic library loading/unloading we _could_ possibly achieve better performance. Still, it serves a reasonable starting point.
